### PR TITLE
Update setup.md

### DIFF
--- a/docs/service-nodes/setup.md
+++ b/docs/service-nodes/setup.md
@@ -1275,7 +1275,7 @@ Service Node Setup, complete the following guides in order:
 	    ??? example "Install `fail2ban`"
 		  1. Get the *xr_proxy-log-path*:
 		  ```
-		  docker inspect exrproxy-env_xr_proxy_1 | grep '"LogPath":'
+		  docker inspect exrproxy-env-xr_proxy-1 | grep '"LogPath":'
 		  ```
 		  This will return something like the following:
 		  ```


### PR DESCRIPTION
The name of xr_proxy container was changed in the fail2ban setup instructions to match new syntax using `-` instead of `_`. Additionally, if a snode operator used the new autobuild script on an older exr-env snode setup, a new logpath has to be queried and appended to the jails config in lines 1393 and 1403. If this is not done, the fail2ban status is changed to 'failed'. and no longer runs.